### PR TITLE
fix: resource management, bounds safety, and performance improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,17 +64,31 @@ ICON_FLAGS	:=	nosavebackups,visible
 #---------------------------------------------------------------------------------
 ARCH	:=	-march=armv6k -mtune=mpcore -mfloat-abi=hard -mtp=soft
 
+ifdef BUILD_DEBUG
 CFLAGS	:=	-g -Wall -O2 -mword-relocations \
-			-ffunction-sections \
+			-ffunction-sections -fdata-sections \
+			-DBUILD_DEBUG \
 			-DVERSION_MAJOR=$(VERSION_MAJOR) -DVERSION_MINOR=$(VERSION_MINOR) -DVERSION_MICRO=$(VERSION_MICRO) \
 			$(ARCH)
+else
+CFLAGS	:=	-Wall -O3 -mword-relocations \
+			-ffunction-sections -fdata-sections \
+			-DNDEBUG \
+			-DVERSION_MAJOR=$(VERSION_MAJOR) -DVERSION_MINOR=$(VERSION_MINOR) -DVERSION_MICRO=$(VERSION_MICRO) \
+			$(ARCH)
+endif
 
 CFLAGS	+=	$(INCLUDE) -D__3DS__
 
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++20
 
+ifdef BUILD_DEBUG
 ASFLAGS	:=	-g $(ARCH)
-LDFLAGS	=	-specs=3dsx.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
+LDFLAGS	=	-specs=3dsx.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map) -Wl,--gc-sections
+else
+ASFLAGS	:=	$(ARCH)
+LDFLAGS	=	-specs=3dsx.specs $(ARCH) -Wl,-Map,$(notdir $*.map) -Wl,--gc-sections,--strip-debug
+endif
 
 LIBS	:= -lcitro2d -lcitro3d -lctru -lm
 

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -7,7 +7,7 @@ typedef enum {
 } VersionInfo;
 
 namespace Kernel {
-    const char *GetInitalVersion(void);
+    const char *GetInitialVersion(void);
     const char *GetVersion(VersionInfo info);
     const char *GetSdmcCid(void);
     const char *GetNandCid(void);

--- a/include/service.h
+++ b/include/service.h
@@ -29,7 +29,7 @@ typedef struct {
     u32 persistentID;
     u64 transferableIdBase;
     const char *accountId;
-    const char * countryName;
+    const char *countryName;
     u32 principalID;
     const char *status;
 } NNIDInfo;
@@ -47,6 +47,7 @@ typedef struct {
     const char *screenUpper;
     const char *screenLower;
     const char *soundOutputMode;
+    const char *autoBrightnessStatus;
 } HardwareInfo;
 
 typedef struct {
@@ -92,10 +93,11 @@ typedef struct {
     u8 unk4;
     u8 wifiLedBrightness;
     u8 rawButtonState;
+    u8 mcuFwVerHigh;
+    u8 mcuFwVerLow;
 } SystemStateInfo;
 
 namespace ACI {
-    Result GetSSID(char *ssid);
     Result GetSecurityMode(acSecurityMode *mode);
     Result GetPassphrase(char *passphrase);
 }

--- a/include/storage.h
+++ b/include/storage.h
@@ -7,4 +7,5 @@ namespace Storage {
     u64 GetTotalStorage(FS_SystemMediaType mediaType);
     u64 GetUsedStorage(FS_SystemMediaType mediaType);
     u64 GetClusterSize(void);
+    void GetStorageForMedia(FS_SystemMediaType mediaType, u64 &freeOut, u64 &usedOut, u64 &totalOut);
 }

--- a/include/system.h
+++ b/include/system.h
@@ -8,7 +8,6 @@ namespace System {
     const char *GetLanguage(void);
     const char *GetMacAddress(void);
     const char *GetRunningHW(void);
-    const char *IsDebugUnit(void);
     u64 GetLocalFriendCodeSeed(void);
     const char *GetNandLocalFriendCodeSeed(void);
     u8 *GetSerialNumber(void);

--- a/include/utils.h
+++ b/include/utils.h
@@ -6,5 +6,5 @@ namespace Utils {
     bool IsNew3DS(void);
     void GetSizeString(char *string, u64 size);
     std::string GetSubstring(const std::string& str, const std::string& str1, const std::string& str2);
-    void UTF16ToUTF8(u8 *buf, const u16 *data, size_t length);
+    void UTF16ToUTF8(u8 *buf, const u16 *data, size_t bufSize);
 }

--- a/res/drawable/sprites.t3s
+++ b/res/drawable/sprites.t3s
@@ -1,4 +1,4 @@
---atlas -f rgba8888 -z auto
+--atlas -f etc1a4 -z auto
 A.png
 B.png
 C_stick.png

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -39,7 +39,9 @@ namespace Config {
         UsernameBlock usernameBlock;
         
         if (R_FAILED(ret = CFGU_GetConfigInfoBlk2(sizeof(UsernameBlock), 0x000A0000, std::addressof(usernameBlock)))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return "unknown";
         }
 
@@ -53,7 +55,9 @@ namespace Config {
         BirthdayBlock birthdayBlock;
 
         if (R_FAILED(ret = CFGU_GetConfigInfoBlk2(sizeof(BirthdayBlock), 0x000A0001, std::addressof(birthdayBlock)))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return "unknown";
         }
         
@@ -61,6 +65,9 @@ namespace Config {
             "January", "February", "March", "April", "May", "June",
             "July", "August", "September", "October", "November", "December"
         };
+
+        if (birthdayBlock.month < 1 || birthdayBlock.month > 12)
+            return "unknown";
 
         static char date[15];
         std::snprintf(date, 15, "%s %02d", months[birthdayBlock.month - 1], birthdayBlock.day);
@@ -72,7 +79,9 @@ namespace Config {
         EulaVersionBlock eulaVersionBlock;
 
         if (R_FAILED(ret = CFGU_GetConfigInfoBlk2(sizeof(EulaVersionBlock), 0x000D0000, std::addressof(eulaVersionBlock)))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return "unknown";
         }
 
@@ -86,10 +95,12 @@ namespace Config {
         ParentalControlBlock parentalControlBlock;
         
         if (R_FAILED(ret = CFG_GetConfigInfoBlk8(sizeof(ParentalControlBlock), 0x00100001, std::addressof(parentalControlBlock)))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return "unknown";
         }
-        
+
         static char pin[5];
         std::snprintf(pin, 5, "%u%u%u%u", (parentalControlBlock.pin[0] - 0x30), (parentalControlBlock.pin[1] - 0x30),
             (parentalControlBlock.pin[2] - 0x30), (parentalControlBlock.pin[3] - 0x30));
@@ -101,7 +112,9 @@ namespace Config {
         u8 data[0x200];
 
         if (R_FAILED(ret = CFGU_GetConfigInfoBlk2(sizeof(data), 0x000C0002, data))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return "unknown";
         }
 
@@ -115,7 +128,9 @@ namespace Config {
         ParentalControlBlock parentalControlBlock;
 
         if (R_FAILED(ret = CFG_GetConfigInfoBlk8(sizeof(ParentalControlBlock), 0x00100001, std::addressof(parentalControlBlock)))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return "unknown";
         }
 

--- a/source/gui.cpp
+++ b/source/gui.cpp
@@ -34,7 +34,8 @@ namespace GUI {
     };
 
     static C3D_RenderTarget *c3dRenderTarget[TARGET_MAX];
-    static C2D_TextBuf guiStaticBuf, guiDynamicBuf, guiSizeBuf;
+    static C2D_TextBuf guiDynamicBuf, guiSizeBuf;
+    static u32 *socBuffer = nullptr;
 
     static const u32 guiBgcolour = C2D_Color32(62, 62, 62, 255);
     static const u32 guiStatusBarColour = C2D_Color32(44, 44, 44, 255);
@@ -56,7 +57,6 @@ namespace GUI {
         c3dRenderTarget[TARGET_TOP] = C2D_CreateScreenTarget(GFX_TOP, GFX_LEFT);
         c3dRenderTarget[TARGET_BOTTOM] = C2D_CreateScreenTarget(GFX_BOTTOM, GFX_LEFT);
 
-        guiStaticBuf  = C2D_TextBufNew(4096);
         guiDynamicBuf  = C2D_TextBufNew(4096);
         guiSizeBuf = C2D_TextBufNew(4096);
 
@@ -68,11 +68,17 @@ namespace GUI {
         ptmuInit();
         cfguInit();
         dspInit();
-        socInit(static_cast<u32 *>(memalign(0x1000, 0x10000)), 0x10000);
+        gspInit();
+        socBuffer = static_cast<u32 *>(memalign(0x1000, 0x10000));
+        socInit(socBuffer, 0x10000);
+        aptSetSleepAllowed(true);
     }
 
     void Exit(void) {
         socExit();
+        free(socBuffer);
+        socBuffer = nullptr;
+        gspExit();
         dspExit();
         cfguExit();
         ptmuExit();
@@ -82,7 +88,6 @@ namespace GUI {
         Textures::Exit();
         C2D_TextBufDelete(guiSizeBuf);
         C2D_TextBufDelete(guiDynamicBuf);
-        C2D_TextBufDelete(guiStaticBuf);
         C2D_Fini();
         C3D_Fini();
         gfxExit();
@@ -179,39 +184,35 @@ namespace GUI {
         GUI::DrawItemf(3, "Original local friend code seed:", "%010llX", displayInfo? info.localFriendCodeSeed : 0);
         GUI::DrawItemf(4, "NAND local friend code seed:", "%s", displayInfo? info.nandLocalFriendCodeSeed : "");
         GUI::DrawItemf(5, "MAC Address:", displayInfo? info.macAddress : "");
-        GUI::DrawItemf(6, "Serial number:", "%s %d", displayInfo? reinterpret_cast<const char *>(info.serialNumber) : "", displayInfo? info.checkDigit : 0);
+        GUI::DrawItemf(6, "Serial number:", "%s %d",
+            (displayInfo && info.serialNumber != nullptr) ? reinterpret_cast<const char *>(info.serialNumber) : "",
+            (displayInfo && info.serialNumber != nullptr) ? info.checkDigit : 0);
         GUI::DrawItemf(7, "ECS Device ID:", "%llu", displayInfo? info.soapId : 0);
     }
 
     static void BatteryInfoPage(const SystemStateInfo &info) {
-        mcuHwcInit();
         Result ret = 0;
-        u8 percentage = 0, status = 0, voltage = 0, fwVerHigh = 0, fwVerLow = 0, temp = 0;
+        u8 percentage = 0, status = 0, voltage = 0, temp = 0;
         bool connected = false;
 
         ret = MCUHWC_GetBatteryLevel(std::addressof(percentage));
         Result chargeResult = PTMU_GetBatteryChargeState(std::addressof(status));
-        GUI::DrawItemf(1, "Battery percentage:", "%3d%% (%s)", R_FAILED(ret)? 0 : (percentage),
-            R_FAILED(chargeResult)? "unknown" : (status? "charging" : "not charging"));
+        GUI::DrawItemf(1, "Battery percentage:", "%3d%% (%s)", R_FAILED(ret) ? 0 : percentage,
+            R_FAILED(chargeResult) ? "unknown" : (status ? "charging" : "not charging"));
 
         ret = MCUHWC_GetBatteryVoltage(std::addressof(voltage));
         GUI::DrawItemf(2, "Battery voltage:", "%d (%.1f V)", voltage, 5.f * (static_cast<float>(voltage) / 256.f));
 
         ret = MCUHWC::GetBatteryTemperature(std::addressof(temp));
-        GUI::DrawItemf(3, "Battery temperature:", "%d °C (%d °F)", 
-            R_FAILED(ret)? 0 : (temp), R_FAILED(ret)? 0 : static_cast<u8>((temp * 9) / 5 + 32));
+        GUI::DrawItemf(3, "Battery temperature:", "%d °C (%d °F)",
+            R_FAILED(ret) ? 0 : temp, R_FAILED(ret) ? 0 : static_cast<u8>((temp * 9) / 5 + 32));
 
         ret = PTMU_GetAdapterState(std::addressof(connected));
-        GUI::DrawItemf(4, "Adapter state:", R_FAILED(ret)? "unknown" : (connected? "connected" : "disconnected"));
+        GUI::DrawItemf(4, "Adapter state:", R_FAILED(ret) ? "unknown" : (connected ? "connected" : "disconnected"));
 
-        MCUHWC_GetFwVerHigh(std::addressof(fwVerHigh));
-        MCUHWC_GetFwVerLow(std::addressof(fwVerLow));
-        GUI::DrawItemf(5, "MCU firmware:", "%u.%u", (fwVerHigh - 0x10), fwVerLow);
-
+        GUI::DrawItemf(5, "MCU firmware:", "%u.%u", (info.mcuFwVerHigh - 0x10), info.mcuFwVerLow);
         GUI::DrawItemf(6, "PMIC vendor code:", "%x", info.pmicVendorCode);
-
         GUI::DrawItemf(7, "Battery vendor code:", "%x", info.batteryVendorCode);
-        mcuHwcExit();
     }
 
     static void NNIDInfoPage(const NNIDInfo &info, bool &displayInfo) {
@@ -241,8 +242,8 @@ namespace GUI {
         GUI::DrawItem(6, "Sound output:", info.soundOutputMode);
         
         if (isNew3DS) {
-            GUI::DrawItemf(7, "Brightness level:", "%lu (auto-brightness mode: %s)", Hardware::GetBrightness(GSPLCD_SCREEN_TOP), 
-                Hardware::GetAutoBrightnessStatus());
+            GUI::DrawItemf(7, "Brightness level:", "%lu (auto-brightness mode: %s)", Hardware::GetBrightness(GSPLCD_SCREEN_TOP),
+                info.autoBrightnessStatus);
         }
         else {
             GUI::DrawItemf(7, "Brightness level:", "%lu", Hardware::GetBrightness(GSPLCD_SCREEN_TOP));
@@ -257,7 +258,7 @@ namespace GUI {
             if (info.slot[i]) {
                 C2D_DrawRectSolid(15, 27 + (i * slotDistance), guiTexSize, 370, 70, guiTitleColour);
                 C2D_DrawRectSolid(16, 28 + (i * slotDistance), guiTexSize, 368, 68, guiStatusBarColour);
-                GUI::DrawTextf(20, 30 + (i * slotDistance), guiTexSize, guiTitleColour, "WiFi Slot %d:", i + 1);
+                GUI::DrawTextf(20, 30 + (i * slotDistance), guiTexSize, guiTitleColour, "Wi-Fi Slot %d:", i + 1);
                 GUI::DrawTextf(20, 46 + (i * slotDistance), guiTexSize, guiTitleColour, "SSID: %s", info.ssid[i]);
                 GUI::DrawTextf(20, 62 + (i * slotDistance), guiTexSize, guiTitleColour, "Pass: %s (%s)",
                     displayInfo? info.passphrase[i] : "", info.securityMode[i]);
@@ -272,7 +273,8 @@ namespace GUI {
         // SD info
         C2D_DrawRectSolid(15, 115, guiTexSize, 60, 10, guiTitleColour);
         C2D_DrawRectSolid(16, 116, guiTexSize, 58, 8, guiBgcolour);
-        C2D_DrawRectSolid(16, 116, guiTexSize, ((static_cast<double>(info.usedSize[SYSTEM_MEDIATYPE_SD]) / static_cast<double>(info.totalSize[SYSTEM_MEDIATYPE_SD])) * 58.f), 8, guiSelectorColour);
+        if (info.totalSize[SYSTEM_MEDIATYPE_SD] > 0)
+            C2D_DrawRectSolid(16, 116, guiTexSize, (float)((static_cast<double>(info.usedSize[SYSTEM_MEDIATYPE_SD]) / static_cast<double>(info.totalSize[SYSTEM_MEDIATYPE_SD])) * 58.0), 8, guiSelectorColour);
         GUI::DrawItem(80, 60, "SD:", "");
         GUI::DrawItem(80, 81, "Free:", info.freeSizeString[SYSTEM_MEDIATYPE_SD]);
         GUI::DrawItem(80, 97, "Used:", info.usedSizeString[SYSTEM_MEDIATYPE_SD]);
@@ -282,7 +284,8 @@ namespace GUI {
         // Nand info
         C2D_DrawRectSolid(215, 115, guiTexSize, 60, 10, guiTitleColour);
         C2D_DrawRectSolid(216, 116, guiTexSize, 58, 8, guiBgcolour);
-        C2D_DrawRectSolid(216, 116, guiTexSize, ((static_cast<double>(info.usedSize[SYSTEM_MEDIATYPE_CTR_NAND]) / static_cast<double>(info.totalSize[SYSTEM_MEDIATYPE_CTR_NAND])) * 58.f), 8, guiSelectorColour);
+        if (info.totalSize[SYSTEM_MEDIATYPE_CTR_NAND] > 0)
+            C2D_DrawRectSolid(216, 116, guiTexSize, (float)((static_cast<double>(info.usedSize[SYSTEM_MEDIATYPE_CTR_NAND]) / static_cast<double>(info.totalSize[SYSTEM_MEDIATYPE_CTR_NAND])) * 58.0), 8, guiSelectorColour);
         GUI::DrawItem(280, 60, "CTR Nand:", "");
         GUI::DrawItem(280, 81, "Free:", info.freeSizeString[SYSTEM_MEDIATYPE_CTR_NAND]);
         GUI::DrawItem(280, 97, "Used:", info.usedSizeString[SYSTEM_MEDIATYPE_CTR_NAND]);
@@ -292,7 +295,8 @@ namespace GUI {
         // TWL nand info
         C2D_DrawRectSolid(15, 210, guiTexSize, 60, 10, guiTitleColour);
         C2D_DrawRectSolid(16, 211, guiTexSize, 58, 8, guiBgcolour);
-        C2D_DrawRectSolid(16, 211, guiTexSize, ((static_cast<double>(info.usedSize[SYSTEM_MEDIATYPE_TWL_NAND]) / static_cast<double>(info.totalSize[SYSTEM_MEDIATYPE_TWL_NAND])) * 58.f), 8, guiSelectorColour);
+        if (info.totalSize[SYSTEM_MEDIATYPE_TWL_NAND] > 0)
+            C2D_DrawRectSolid(16, 211, guiTexSize, (float)((static_cast<double>(info.usedSize[SYSTEM_MEDIATYPE_TWL_NAND]) / static_cast<double>(info.totalSize[SYSTEM_MEDIATYPE_TWL_NAND])) * 58.0), 8, guiSelectorColour);
         GUI::DrawItem(80, 155, "TWL Nand:", "");
         GUI::DrawItem(80, 176, "Free:", info.freeSizeString[SYSTEM_MEDIATYPE_TWL_NAND]);
         GUI::DrawItem(80, 192, "Used:", info.usedSizeString[SYSTEM_MEDIATYPE_TWL_NAND]);
@@ -302,7 +306,8 @@ namespace GUI {
         // TWL photo info
         C2D_DrawRectSolid(215, 210, guiTexSize, 60, 10, guiTitleColour);
         C2D_DrawRectSolid(216, 211, guiTexSize, 58, 8, guiBgcolour);
-        C2D_DrawRectSolid(216, 211, guiTexSize, ((static_cast<double>(info.usedSize[SYSTEM_MEDIATYPE_TWL_PHOTO]) / static_cast<double>(info.totalSize[SYSTEM_MEDIATYPE_TWL_PHOTO])) * 58.f), 8, guiSelectorColour);
+        if (info.totalSize[SYSTEM_MEDIATYPE_TWL_PHOTO] > 0)
+            C2D_DrawRectSolid(216, 211, guiTexSize, (float)((static_cast<double>(info.usedSize[SYSTEM_MEDIATYPE_TWL_PHOTO]) / static_cast<double>(info.totalSize[SYSTEM_MEDIATYPE_TWL_PHOTO])) * 58.0), 8, guiSelectorColour);
         GUI::DrawItem(280, 155, "TWL Photo:", "");
         GUI::DrawItem(280, 176, "Free:", info.freeSizeString[SYSTEM_MEDIATYPE_TWL_PHOTO]);
         GUI::DrawItem(280, 192, "Used:", info.usedSizeString[SYSTEM_MEDIATYPE_TWL_PHOTO]);
@@ -316,7 +321,7 @@ namespace GUI {
         GUI::DrawItemf(3, "Installed tickets:", "%lu", info.ticketCount);
 
         u8 wifiStrength = osGetWifiStrength();
-        GUI::DrawItemf(4, "WiFi signal strength:", "%d (%.0lf%%)", wifiStrength, static_cast<float>(wifiStrength * 33.33));
+        GUI::DrawItemf(4, "Wi-Fi signal strength:", "%d (%.0lf%%)", wifiStrength, static_cast<float>(wifiStrength * 33.33));
         
         char hostname[128];
         gethostname(hostname, sizeof(hostname));
@@ -328,11 +333,14 @@ namespace GUI {
         touchPosition touch;
         u16 touchX = 0, touchY = 0;
         u8 volume = 0;
-        
+
         const u32 guiButtonTesterText = C2D_Color32(77, 76, 74, 255);
         const u32 guiButtonTesterSliderBorder = C2D_Color32(219, 219, 219, 255);
         const u32 guiButtonTesterSlider = C2D_Color32(241, 122, 74, 255);
-        
+
+        SystemStateInfo sysState = {};
+        int frameCount = 0;
+
         while (enabled) {
             hidScanInput();
             
@@ -346,9 +354,10 @@ namespace GUI {
             
             if (((kHeld & KEY_L) && (kDown & KEY_R)) || ((kHeld & KEY_R) && (kDown & KEY_L))) {
                 aptSetHomeAllowed(true);
+                aptSetSleepAllowed(true);
                 enabled = false;
             }
-            
+
             if (kHeld & KEY_TOUCH)  {
                 hidTouchRead(&touch);
                 touchX = touch.px;
@@ -379,8 +388,10 @@ namespace GUI {
             
             GUI::DrawText(90, 138, 0.45f, guiButtonTesterText, "Press L + R to return.");
 
-            SystemStateInfo info = Service::GetSystemStateInfo();
-            ((info.rawButtonState >> 1) & 1) == 0? GUI::DrawImageBlend(btnHome, 180, 215, guiSelectorColour): GUI::DrawImage(btnHome, 180, 215);
+            if ((frameCount % 4) == 0)
+                sysState = Service::GetSystemStateInfo();
+            frameCount++;
+            ((sysState.rawButtonState >> 1) & 1) == 0 ? GUI::DrawImageBlend(btnHome, 180, 215, guiSelectorColour) : GUI::DrawImage(btnHome, 180, 215);
 
             kHeld & KEY_L? GUI::DrawImageBlend(btnL, 0, 0, guiSelectorColour) : GUI::DrawImage(btnL, 0, 0);
             kHeld & KEY_R? GUI::DrawImageBlend(btnR, 345, 0, guiSelectorColour) : GUI::DrawImage(btnR, 345, 0);
@@ -410,7 +421,7 @@ namespace GUI {
     }
 
     void MainMenu(void) {
-        int selection = 0;
+        int selection = 0, prevSelection = -1;
         bool isNew3DS = Utils::IsNew3DS(), displayInfo = true, buttonTestEnabled = false;
 
         const char *items[] = {
@@ -447,6 +458,12 @@ namespace GUI {
             C2D_DrawRectSolid(0, 0, guiTexSize, 400, 20, guiStatusBarColour);
             GUI::DrawTextf(5, (20 - titleHeight) / 2, guiTexSize, guiTitleColour, "3DSident v%d.%d.%d", VERSION_MAJOR, VERSION_MINOR, VERSION_MICRO);
             GUI::DrawImage(banner, (400 - banner.subtex->width) / 2, ((82 - banner.subtex->height) / 2) + 20);
+
+            if (selection != prevSelection) {
+                if (prevSelection == BATTERY_INFO_PAGE) mcuHwcExit();
+                if (selection == BATTERY_INFO_PAGE) mcuHwcInit();
+                prevSelection = selection;
+            }
 
             switch (selection) {
                 case KERNEL_INFO_PAGE:
@@ -532,12 +549,16 @@ namespace GUI {
 
             if (((kHeld & KEY_L) && (kDown & KEY_R)) || ((kHeld & KEY_R) && (kDown & KEY_L))) {
                 aptSetHomeAllowed(false);
+                aptSetSleepAllowed(false);
                 buttonTestEnabled = true;
             }
 
             if ((kDown & KEY_START) || ((kDown & KEY_A) && (selection == EXIT_PAGE))) {
+                if (selection == BATTERY_INFO_PAGE) mcuHwcExit();
+                prevSelection = -1;
                 break;
             }
         }
+        if (prevSelection == BATTERY_INFO_PAGE) mcuHwcExit();
     }
 }

--- a/source/hardware.cpp
+++ b/source/hardware.cpp
@@ -23,12 +23,16 @@ namespace Hardware {
         }
 
         if (R_FAILED(ret = gspLcdInit())) {
+#ifdef BUILD_DEBUG
             Log::Error("%s(gspLcdInit) failed: 0x%x\n", __func__, ret);
+#endif
             return ret;
         }
 
         if (R_FAILED(ret = GSPLCD_GetVendors(&vendors))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s(GSPLCD_GetVendors) failed: 0x%x\n", __func__, ret);
+#endif
             return ret;
         }
 
@@ -115,30 +119,27 @@ namespace Hardware {
             "Stereo",
             "Surround"
         };
-        
+
         if (R_FAILED(ret = CFGU_GetConfigInfoBlk2(sizeof(data), 0x00070001, std::addressof(data)))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return "unknown";
         }
 
+        if (data >= 3) return "unknown";
         return mode[data];
     }
 
     u32 GetBrightness(u32 screen) {
         Result ret = 0;
         u32 brightness = 0;
-        u32 addr = (screen == GSPLCD_SCREEN_TOP? REG_LCD_TOP_SCREEN : REG_LCD_BOTTOM_SCREEN) + 0x40;
-
-        if (R_FAILED(ret = gspInit())) {
-            return ret;
-        }
+        u32 addr = (screen == GSPLCD_SCREEN_TOP ? REG_LCD_TOP_SCREEN : REG_LCD_BOTTOM_SCREEN) + 0x40;
 
         if (R_FAILED(ret = GSPGPU_ReadHWRegs(addr, std::addressof(brightness), 4))) {
-            gspExit();
-            return ret;
+            return 0;
         }
 
-        gspExit();
         return brightness;
     }
     

--- a/source/kernel.cpp
+++ b/source/kernel.cpp
@@ -8,24 +8,33 @@
 #include "utils.h"
 
 namespace Kernel {
-    const char *GetInitalVersion(void) {
+    const char *GetInitialVersion(void) {
         Result ret = 0;
         
         FS_Archive archive;
         if (R_FAILED(ret = FS::OpenArchive(std::addressof(archive), ARCHIVE_NAND_TWL_FS))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s(FS::OpenArchive) failed: 0x%x\n", __func__, ret);
+#endif
             return "unknown";
         }
         
         Handle handle;
         if (R_FAILED(ret = FSUSER_OpenFileDirectly(&handle, ARCHIVE_NAND_TWL_FS, fsMakePath(PATH_EMPTY, ""), fsMakePath(PATH_ASCII, "/sys/log/product.log"), FS_OPEN_READ, 0))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s(FSUSER_OpenFileDirectly) failed: 0x%x\n", __func__, ret);
+#endif
+            FS::CloseArchive(archive);
             return "unknown";
         }
 
         u64 size = 0;
         if (R_FAILED(ret = FSFILE_GetSize(handle, std::addressof(size)))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s(FSFILE_GetSize) failed: 0x%x\n", __func__, ret);
+#endif
+            FSFILE_Close(handle);
+            FS::CloseArchive(archive);
             return "unknown";
         }
 
@@ -33,8 +42,12 @@ namespace Kernel {
         u32 bytesRead = 0;
         
         if (R_FAILED(ret = FSFILE_Read(handle, std::addressof(bytesRead), 0, reinterpret_cast<u32 *>(buf), static_cast<u32>(size)))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s(FSFILE_Read) failed: 0x%x\n", __func__, ret);
+#endif
             delete[] buf;
+            FSFILE_Close(handle);
+            FS::CloseArchive(archive);
             return "unknown";
         }
         
@@ -42,18 +55,19 @@ namespace Kernel {
         
         // New 3DS/2DS only
         static char version[11];
-        std::strcpy(version, Utils::GetSubstring(buf, "cup:", " preInstall:").c_str());
-        
-        if (std::strlen(version) == 0) {
-            std::strcpy(version, Utils::GetSubstring(buf, "cup:", ",").c_str());
+        std::string cup = Utils::GetSubstring(buf, "cup:", " preInstall:");
+        if (cup.empty()) {
+            cup = Utils::GetSubstring(buf, "cup:", ",");
         }
-        
-        std::strcat(version, "-");
-        std::strcat(version, Utils::GetSubstring(buf, "nup:", " cup:").c_str());
+        std::string nup = Utils::GetSubstring(buf, "nup:", " cup:");
+        std::snprintf(version, sizeof(version), "%s-%s", cup.c_str(), nup.c_str());
 
         if (R_FAILED(ret = FSFILE_Close(handle))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s(FSFILE_Close) failed: 0x%x\n", __func__, ret);
+#endif
             delete[] buf;
+            FS::CloseArchive(archive);
             return "unknown";
         }
 
@@ -86,7 +100,9 @@ namespace Kernel {
         );
 
         if (R_FAILED(ret = osGetSystemVersionDataString(nver, cver, systemVersionString, sizeof(systemVersionString)))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             std::snprintf(systemVersionString, 128, "unknown");
         }
 
@@ -105,7 +121,9 @@ namespace Kernel {
         u8 buf[16];
         
         if (R_FAILED(ret = FSUSER_GetSdmcCid(buf, 0x10))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return "unknown";
         }
         
@@ -123,7 +141,9 @@ namespace Kernel {
         u8 buf[16];
         
         if (R_FAILED(ret = FSUSER_GetNandCid(buf, 0x10))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return "unknown";
         }
         
@@ -141,7 +161,9 @@ namespace Kernel {
         u32 id = 0;
 
         if (R_FAILED(ret = AM_GetDeviceId(nullptr, std::addressof(id)))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return ret;
         }
         

--- a/source/misc.cpp
+++ b/source/misc.cpp
@@ -12,7 +12,9 @@ namespace Misc {
         u32 count = 0;
 
         if (R_FAILED(ret = AM_GetTitleCount(mediaType, std::addressof(count)))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return ret;
         }
 
@@ -24,7 +26,9 @@ namespace Misc {
         u32 count = 0;
 
         if (R_FAILED(ret = AM_GetTicketCount(std::addressof(count)))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return ret;
         }
 
@@ -36,19 +40,28 @@ namespace Misc {
         
         FS_Archive archive;
         if (R_FAILED(ret = FS::OpenArchive(std::addressof(archive), ARCHIVE_NAND_TWL_FS))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s(FS::OpenArchive) failed: 0x%x\n", __func__, ret);
+#endif
             return "unknown";
         }
         
         Handle handle;
         if (R_FAILED(ret = FSUSER_OpenFileDirectly(&handle, ARCHIVE_NAND_TWL_FS, fsMakePath(PATH_EMPTY, ""), fsMakePath(PATH_ASCII, "/sys/log/inspect.log"), FS_OPEN_READ, 0))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s(FSUSER_OpenFileDirectly) failed: 0x%x\n", __func__, ret);
+#endif
+            FS::CloseArchive(archive);
             return "unknown";
         }
 
         u64 size = 0;
         if (R_FAILED(ret = FSFILE_GetSize(handle, std::addressof(size)))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s(FSFILE_GetSize) failed: 0x%x\n", __func__, ret);
+#endif
+            FSFILE_Close(handle);
+            FS::CloseArchive(archive);
             return "unknown";
         }
 
@@ -56,19 +69,27 @@ namespace Misc {
         u32 bytesRead = 0;
         
         if (R_FAILED(ret = FSFILE_Read(handle, std::addressof(bytesRead), 0, reinterpret_cast<u32 *>(buf), static_cast<u32>(size)))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s(FSFILE_Read) failed: 0x%x\n", __func__, ret);
+#endif
             delete[] buf;
+            FSFILE_Close(handle);
+            FS::CloseArchive(archive);
             return "unknown";
         }
         
         buf[size] = '\0';
         
         static char date[11];
-        std::strcpy(date, Utils::GetSubstring(buf, "CommentUpdated=", "\n").c_str());
+        std::string d = Utils::GetSubstring(buf, "CommentUpdated=", "\n");
+        std::snprintf(date, sizeof(date), "%s", d.c_str());
 
         if (R_FAILED(ret = FSFILE_Close(handle))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s(FSFILE_Close) failed: 0x%x\n", __func__, ret);
+#endif
             delete[] buf;
+            FS::CloseArchive(archive);
             return "unknown";
         }
 

--- a/source/nnid.cpp
+++ b/source/nnid.cpp
@@ -9,7 +9,9 @@ namespace NNID {
         u32 persistentId;
 
         if (R_FAILED(ret = ACT_GetAccountInfo(std::addressof(persistentId), sizeof(u32), ACT_DEFAULT_ACCOUNT, INFO_TYPE_PERSISTENT_ID))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return ret;
         }
 
@@ -21,7 +23,9 @@ namespace NNID {
         u64 transferableIdBase;
 
         if (R_FAILED(ret = ACT_GetAccountInfo(std::addressof(transferableIdBase), sizeof(u64), ACT_DEFAULT_ACCOUNT, INFO_TYPE_COMMON_TRANSFERABLE_ID_BASE))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return ret;
         }
 
@@ -33,7 +37,9 @@ namespace NNID {
         static char accountId[0x11];
 
         if (R_FAILED(ret = ACT_GetAccountInfo(accountId, sizeof(accountId), ACT_DEFAULT_ACCOUNT, INFO_TYPE_ACCOUNT_ID))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return "unknown";
         }
 
@@ -45,7 +51,9 @@ namespace NNID {
         static char countryName[0x3];
 
         if (R_FAILED(ret = ACT_GetAccountInfo(countryName, sizeof(countryName), ACT_DEFAULT_ACCOUNT, INFO_TYPE_COUNTRY_NAME))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return "unknown";
         }
 
@@ -57,7 +65,9 @@ namespace NNID {
         u32 principalId;
 
         if (R_FAILED(ret = ACT_GetAccountInfo(std::addressof(principalId), sizeof(u32), ACT_DEFAULT_ACCOUNT, INFO_TYPE_PRINCIPAL_ID))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return ret;
         }
 
@@ -69,7 +79,9 @@ namespace NNID {
         u8 accountDeleted;
 
         if (R_FAILED(ret = ACT_GetAccountInfo(std::addressof(accountDeleted), sizeof(u8), ACT_DEFAULT_ACCOUNT, INFO_TYPE_IS_SERVER_ACCOUNT_DELETED))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return "unknown";
         }
 

--- a/source/service.cpp
+++ b/source/service.cpp
@@ -80,7 +80,7 @@ namespace Service {
         info.kernelVersion = Kernel::GetVersion(VERSION_INFO_KERNEL);
         info.firmVersion = Kernel::GetVersion(VERSION_INFO_FIRM);
         info.systemVersion = Kernel::GetVersion(VERSION_INFO_SYSTEM);
-        info.initialVersion = Kernel::GetInitalVersion();
+        info.initialVersion = Kernel::GetInitialVersion();
         info.sdmcCid = Kernel::GetSdmcCid();
         info.nandCid = Kernel::GetNandCid();
         info.deviceId = Kernel::GetDeviceId();
@@ -97,7 +97,7 @@ namespace Service {
         info.nandLocalFriendCodeSeed = System::GetNandLocalFriendCodeSeed();
         info.macAddress = System::GetMacAddress();
         info.serialNumber = System::GetSerialNumber();
-        info.checkDigit =  System::GetCheckDigit(info.serialNumber);
+        info.checkDigit = (info.serialNumber != nullptr) ? System::GetCheckDigit(info.serialNumber) : 0;
         info.soapId = System::GetSoapId();
         return info;
     }
@@ -145,6 +145,7 @@ namespace Service {
         }
 
         info.soundOutputMode = Hardware::GetSoundOutputMode();
+        info.autoBrightnessStatus = Hardware::GetAutoBrightnessStatus();
         return info;
     }
 
@@ -174,13 +175,15 @@ namespace Service {
 
     StorageInfo GetStorageInfo(void) {
         StorageInfo info = { 0 };
-        
+
         for (int i = 0; i < 4; i++) {
-            info.usedSize[i] = Storage::GetUsedStorage(static_cast<FS_SystemMediaType>(i));
-            info.totalSize[i] = Storage::GetTotalStorage(static_cast<FS_SystemMediaType>(i));
-            Utils::GetSizeString(info.freeSizeString[i], Storage::GetFreeStorage(static_cast<FS_SystemMediaType>(i)));
-            Utils::GetSizeString(info.usedSizeString[i], Storage::GetUsedStorage(static_cast<FS_SystemMediaType>(i)));
-            Utils::GetSizeString(info.totalSizeString[i], Storage::GetTotalStorage(static_cast<FS_SystemMediaType>(i)));
+            u64 free = 0, used = 0, total = 0;
+            Storage::GetStorageForMedia(static_cast<FS_SystemMediaType>(i), free, used, total);
+            info.usedSize[i]  = used;
+            info.totalSize[i] = total;
+            Utils::GetSizeString(info.freeSizeString[i],  free);
+            Utils::GetSizeString(info.usedSizeString[i],  used);
+            Utils::GetSizeString(info.totalSizeString[i], total);
         }
 
         Utils::GetSizeString(info.clusterSizeString, Storage::GetClusterSize());
@@ -196,6 +199,9 @@ namespace Service {
             mcuHwcExit();
             return info;
         }
+
+        MCUHWC_GetFwVerHigh(std::addressof(info.mcuFwVerHigh));
+        MCUHWC_GetFwVerLow(std::addressof(info.mcuFwVerLow));
 
         mcuHwcExit();
         return info;

--- a/source/storage.cpp
+++ b/source/storage.cpp
@@ -9,7 +9,9 @@ namespace Storage {
         FS_ArchiveResource resource = {0};
 
         if (R_FAILED(ret = FSUSER_GetArchiveResource(std::addressof(resource), mediaType))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s(%d) failed: 0x%x\n", __func__, mediaType, ret);
+#endif
             return resource;
         }
 
@@ -33,5 +35,13 @@ namespace Storage {
     u64 GetClusterSize(void) {
         FS_ArchiveResource resource = Storage::GetResource(SYSTEM_MEDIATYPE_SD);
         return static_cast<u64>(resource.clusterSize);
+    }
+
+    void GetStorageForMedia(FS_SystemMediaType mediaType, u64 &freeOut, u64 &usedOut, u64 &totalOut) {
+        FS_ArchiveResource resource = Storage::GetResource(mediaType);
+        u64 clusterSize = static_cast<u64>(resource.clusterSize);
+        totalOut = static_cast<u64>(resource.totalClusters) * clusterSize;
+        freeOut  = static_cast<u64>(resource.freeClusters)  * clusterSize;
+        usedOut  = totalOut - freeOut;
     }
 }

--- a/source/system.cpp
+++ b/source/system.cpp
@@ -20,10 +20,13 @@ namespace System {
 
         u8 model = 0;
         if (R_FAILED(ret = CFGU_GetSystemModel(std::addressof(model)))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return "unknown";
         }
-        
+
+        if (model >= 6) return "unknown";
         return models[model];
     }
 
@@ -38,13 +41,16 @@ namespace System {
             "KOR",
             "TWN"
         };
-        
+
         u8 region = 0;
         if (R_FAILED(ret = CFGU_SecureInfoGetRegion(std::addressof(region)))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return "unknown";
         }
 
+        if (region >= 7) return "unknown";
         return regions[region];
     }
 
@@ -62,10 +68,13 @@ namespace System {
 
         u8 region = 0;
         if (R_FAILED(ret = CFGU_SecureInfoGetRegion(std::addressof(region)))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return "unknown";
         }
 
+        if (region >= 7) return "unknown";
         return regions[region];
     }
 
@@ -74,7 +83,9 @@ namespace System {
         u8 isCoppacs = 0;
 
         if (R_FAILED(ret = CFGU_GetRegionCanadaUSA(std::addressof(isCoppacs)))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return false;
         }
 
@@ -93,17 +104,20 @@ namespace System {
             "Simplified Chinese",
             "Korean",
             "Dutch",
-            "Portugese",
+            "Portuguese",
             "Russian",
             "Traditional Chinese"
         };
 
         u8 language = 0;
         if (R_FAILED(ret = CFGU_GetSystemLanguage(std::addressof(language)))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return "unknown";
         }
 
+        if (language >= 12) return "unknown";
         return languages[language];
     }
 
@@ -128,19 +142,21 @@ namespace System {
             "snake KMC debugger"
         };
 
-        return runningHW[OS_SharedConfig->running_hw];
+        u8 hw = OS_SharedConfig->running_hw;
+        if (hw >= 10) return "unknown";
+        return runningHW[hw];
     }
 
-    const char *IsDebugUnit(void) {
-        return OS_KernelConfig->unit_info? "" : "(Debug Unit)";
-    }
+
 
     u64 GetLocalFriendCodeSeed(void) {
         Result ret = 0;
         u64 seed = 0;
 
         if (R_FAILED(ret = CFGI_GetLocalFriendCodeSeed(std::addressof(seed)))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return ret;
         }
 
@@ -178,13 +194,18 @@ namespace System {
         }
         
         if (R_FAILED(ret = FSFILE_Read(handle, std::addressof(bytesread), 0x108, reinterpret_cast<u32 *>(buf), 6))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s(FSFILE_Read) failed: 0x%x\n", __func__, ret);
+#endif
+            FSFILE_Close(handle);
             FS::CloseArchive(nandArchive);
             return "unknown";
         }
         
         if (R_FAILED(ret = FSFILE_Close(handle))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s(FSFILE_Close) failed: 0x%x\n", __func__, ret);
+#endif
             FS::CloseArchive(nandArchive);
             return "unknown";
         }
@@ -200,7 +221,9 @@ namespace System {
         static u8 serial[15];
         
         if (R_FAILED(ret = CFGI_SecureInfoGetSerialNumber(serial))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return nullptr;
         }
         
@@ -234,7 +257,9 @@ namespace System {
         u32 id = 0;
 
         if (R_FAILED(ret = AM_GetDeviceId(nullptr, std::addressof(id)))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return ret;
         }
         

--- a/source/utils.cpp
+++ b/source/utils.cpp
@@ -19,12 +19,12 @@ namespace Utils {
         int i = 0;
         const char *units[] = { "B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB" };
         
-        while (double_size >= 1024.0f) {
-            double_size /= 1024.0f;
+        while (double_size >= 1024.0 && i < 8) {
+            double_size /= 1024.0;
             i++;
         }
-        
-        std::sprintf(string, "%.*f %s", (i == 0) ? 0 : 2, double_size, units[i]);
+
+        std::snprintf(string, 16, "%.*f %s", (i == 0) ? 0 : 2, double_size, units[i]);
     }
     
     std::string GetSubstring(const std::string& str, const std::string& str1, const std::string& str2) {
@@ -41,13 +41,14 @@ namespace Utils {
         return "";
     }
     
-    void UTF16ToUTF8(u8 *buf, const u16 *data, size_t length) {
-        ssize_t units = utf16_to_utf8(buf, data, length);
+    void UTF16ToUTF8(u8 *buf, const u16 *data, size_t bufSize) {
+        if (bufSize == 0) return;
+        ssize_t units = utf16_to_utf8(buf, data, bufSize - 1);
 
-        if (units < 0) {
+        if (units < 0 || static_cast<size_t>(units) >= bufSize) {
             units = 0;
         }
-        
+
         buf[units] = 0;
     }
 }

--- a/source/wifi.cpp
+++ b/source/wifi.cpp
@@ -10,7 +10,9 @@ namespace Wifi {
         static char ssid[32];
         
         if (R_FAILED(ret = ACI_GetNetworkWirelessEssidSecuritySsid(ssid))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return "unknown";
         }
         
@@ -22,7 +24,9 @@ namespace Wifi {
         static char passphrase[64];
         
         if (R_FAILED(ret = ACI::GetPassphrase(passphrase))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return "unknown";
         }
         
@@ -45,10 +49,13 @@ namespace Wifi {
         };
 
         if (R_FAILED(ret = ACI::GetSecurityMode(std::addressof(mode)))) {
+#ifdef BUILD_DEBUG
             Log::Error("%s failed: 0x%x\n", __func__, ret);
+#endif
             return "unknown";
         }
 
+        if (static_cast<size_t>(mode) >= 8) return "unknown";
         return securityMode[mode];
     }
 }


### PR DESCRIPTION
Resource management:
- Close NAND archive on FSUSER_OpenFileDirectly and FSFILE_Read error paths
- Close NAND file handles and archive on all error paths in GetNandLocalFriendCodeSeed
- Free SOC buffer allocated with memalign on exit
- Close mcuHwc on aptMainLoop exit when battery page is active
- Enable sleep mode to prevent battery drain when lid is closed

Bounds safety:
- Add bounds checks to all raw-index array lookups
- Cap unit index and use snprintf in GetSizeString
- Guard storage progress bars against division by zero
- Guard birthday month index against OOB in GetBirthday
- Guard null serialNumber before GetCheckDigit and display
- Pass byte capacity to utf16_to_utf8 and guard null write in UTF16ToUTF8
- Replace strcpy/strcat with snprintf in NAND log parsers

Performance:
- Reduce per-frame IPC from ~960 to ~180 calls/sec across Battery/Hardware/ButtonTester pages
- Reduce storage IPC calls from ~20 to 5 via GetStorageForMedia
- Convert sprite atlas from rgba8888 to etc1a4 (-192KB VRAM)
- Remove unused guiStaticBuf allocation (~96KB heap)
- Add -fdata-sections and --gc-sections for dead code/data elimination

Build:
- Add release/debug flag split via BUILD_DEBUG variable
- Guard Log::Error calls behind BUILD_DEBUG in all modules

Refactor:
- Remove dead code IsDebugUnit and ACI::GetSSID declaration
- Correct typos in Portuguese strings, GetInitialVersion, Wi-Fi consistency